### PR TITLE
Catch for check_orientation exceptions

### DIFF
--- a/src/torch/prefect_flows/tasks/check_orientation.py
+++ b/src/torch/prefect_flows/tasks/check_orientation.py
@@ -9,8 +9,12 @@ from prefect.orion.schemas.states import Failed
 def check_orientation(specimen: Specimen, config):
     flow_run_id = prefect.context.get_run_context().task_run.flow_run_id.hex
 
-    if is_portrait(specimen.upload_path):
-        save_specimen(specimen, config, flow_run_id)
-    else:
-        save_specimen(specimen, config, flow_run_id, 'Failed', 'check_orientation')
-        return Failed(message=f"Specimen {specimen.id}-{specimen.name} incorrect orientation")
+    try:
+        if is_portrait(specimen.upload_path):
+            save_specimen(specimen, config, flow_run_id)
+        else:
+            save_specimen(specimen, config, flow_run_id, 'Failed', 'check_orientation')
+            return Failed(message=f"Specimen {specimen.id}-{specimen.name} incorrect orientation")
+    except Exception as e:
+            save_specimen(specimen, config, flow_run_id, 'Failed', 'check_orientation - file read error')
+            return Failed(message=f"Unable to determine image orientation of {specimen.id}-{specimen.name} at path {specimen.upload_path} exception: {e}")


### PR DESCRIPTION
This doesn't solve the underlying problem, but should catch and log the appropriate exceptions and image paths that are being read.